### PR TITLE
updating ping method

### DIFF
--- a/NetworkEvents.iml
+++ b/NetworkEvents.iml
@@ -8,8 +8,6 @@
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <output url="file://$MODULE_DIR$/build/classes/main" />
-    <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkEventsConfig.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkEventsConfig.java
@@ -17,8 +17,8 @@ package com.github.pwittchen.networkevents.library;
 
 public final class NetworkEventsConfig {
     public final static String TAG = "NetworkEvents";
-    public final static byte[] IP_ADDRESS = new byte[]{4, 2, 2, 2}; // Why this address? Read more at: http://www.tummy.com/articles/famous-dns-server/
-    public final static int PING_TIMEOUT_MS = 5000;
+    public final static String URL = "http://www.google.com";
+    public final static int TIMEOUT = 30 * 1000;
     public final static String INTENT = "networkevents.intent.action.INTERNET_CONNECTION_STATE_CHANGED";
     public final static String INTENT_EXTRA = "networkevents.intent.extra.CONNECTED_TO_INTERNET";
 }

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/Ping.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/Ping.java
@@ -28,7 +28,7 @@ public final class Ping extends AsyncTask<Void, Void, Boolean> {
 
     @Override
     protected Boolean doInBackground(Void... params) {
-        return NetworkHelper.ping(NetworkEventsConfig.IP_ADDRESS, NetworkEventsConfig.PING_TIMEOUT_MS);
+        return NetworkHelper.ping(NetworkEventsConfig.URL, NetworkEventsConfig.TIMEOUT);
     }
 
     @Override


### PR DESCRIPTION
Method with checking internet connection with `InetAddress.getByAddress(ipAddress).isReachable(timeout)` is not reliable and sometimes returns incorrect results.
That's why implementation of `ping` method was changed. In addition, `getWifiInfo` method was removed, because it's not used and not necessary here.