### PR TITLE
creating wrapper for Ping class

### DIFF
--- a/example-dagger/example-dagger.iml
+++ b/example-dagger/example-dagger.iml
@@ -82,6 +82,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/example/example.iml
+++ b/example/example.iml
@@ -82,6 +82,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 21 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/network-events-library/network-events-library.iml
+++ b/network-events-library/network-events-library.iml
@@ -93,8 +93,8 @@
     <orderEntry type="library" exported="" scope="TEST" name="objenesis-1.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="dexmaker-1.0" level="project" />
     <orderEntry type="library" exported="" name="otto-1.3.6" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="junit-dep-4.10" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="junit-dep-4.10" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="dexmaker-mockito-1.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="mockito-core-1.9.5" level="project" />
   </component>

--- a/network-events-library/src/androidTest/java/com/github/pwittchen/networkevents/library/receiver/NetworkConnectionChangeReceiverTest.java
+++ b/network-events-library/src/androidTest/java/com/github/pwittchen/networkevents/library/receiver/NetworkConnectionChangeReceiverTest.java
@@ -15,7 +15,6 @@
  */
 package com.github.pwittchen.networkevents.library.receiver;
 
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.github.pwittchen.networkevents.library.ConnectivityStatus;
@@ -119,7 +118,7 @@ public class NetworkConnectionChangeReceiverTest {
     }
 
     private void onPostReceiveAndSleep(ConnectivityStatus connectivityStatus) throws InterruptedException {
-        receiver.onPostReceive(InstrumentationRegistry.getContext(), connectivityStatus);
+        receiver.onPostReceive(connectivityStatus);
         Thread.sleep(2000); // wait a while for async operation
     }
 

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkEvents.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkEvents.java
@@ -52,7 +52,7 @@ public final class NetworkEvents {
         checkNotNull(context, "context == null");
         checkNotNull(bus, "bus == null");
         this.context = context;
-        this.networkConnectionChangeReceiver = new NetworkConnectionChangeReceiver(bus);
+        this.networkConnectionChangeReceiver = new NetworkConnectionChangeReceiver(bus, new PingWrapper(context));
         this.internetConnectionChangeReceiver = new InternetConnectionChangeReceiver(bus);
         this.wifiSignalStrengthChangeReceiver = new WifiSignalStrengthChangeReceiver(bus);
     }

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkHelper.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkHelper.java
@@ -66,7 +66,6 @@ public final class NetworkHelper {
             int responseCode = connection.getResponseCode();
             return (200 <= responseCode && responseCode <= 399);
         } catch (IOException exception) {
-        	// I think it would be help with printing the exception. :)
         	exception.printStackTrace();
             return false;
         }

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/Ping.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/Ping.java
@@ -23,7 +23,7 @@ import android.os.AsyncTask;
  * Asynchronous Task which pings remote host in a separate thread
  * in order to check Internet connection
  */
-public final class Ping extends AsyncTask<Void, Void, Boolean> implements Task {
+public final class Ping extends AsyncTask<Void, Void, Boolean> {
     private final Context context;
 
     public Ping(Context context) {
@@ -41,10 +41,5 @@ public final class Ping extends AsyncTask<Void, Void, Boolean> implements Task {
         Intent intent = new Intent(NetworkEventsConfig.INTENT);
         intent.putExtra(NetworkEventsConfig.INTENT_EXTRA, connectedToInternet);
         context.sendBroadcast(intent);
-    }
-
-    @Override
-    public void execute() {
-        super.execute();
     }
 }

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/PingWrapper.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/PingWrapper.java
@@ -1,0 +1,22 @@
+package com.github.pwittchen.networkevents.library;
+
+import android.content.Context;
+
+/**
+ * Wrapper for Ping class is created,
+ * because we need separate instance of Ping class for every thread,
+ * to execute AsyncTasks properly.
+ */
+public final class PingWrapper implements Task {
+
+    private Context context;
+
+    public PingWrapper(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void execute() {
+        new Ping(context).execute();
+    }
+}


### PR DESCRIPTION
This change simplifies the code and allow to create new `Ping` instance for each thread, what is required by AsyncTask. In addition, it removed dependency to `Ping` class in `NetworkConnectionChangeReceiver`.