### PR TITLE
adding abstraction for a message logger

### DIFF
--- a/network-events-library/src/androidTest/java/com/github/pwittchen/networkevents/library/receiver/InternetConnectionChangeReceiverTest.java
+++ b/network-events-library/src/androidTest/java/com/github/pwittchen/networkevents/library/receiver/InternetConnectionChangeReceiverTest.java
@@ -18,6 +18,7 @@ package com.github.pwittchen.networkevents.library.receiver;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.github.pwittchen.networkevents.library.ConnectivityStatus;
+import com.github.pwittchen.networkevents.library.logger.Logger;
 import com.github.pwittchen.networkevents.library.NetworkState;
 import com.github.pwittchen.networkevents.library.TestUtils;
 import com.github.pwittchen.networkevents.library.event.ConnectivityChanged;
@@ -28,6 +29,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +47,7 @@ public class InternetConnectionChangeReceiverTest {
     @Before
     public void setUp() throws Exception {
         this.bus = new Bus(ThreadEnforcer.ANY);
-        this.receiver = new InternetConnectionChangeReceiver(bus);
+        this.receiver = new InternetConnectionChangeReceiver(bus, Mockito.mock(Logger.class));
         this.connectivityChangeEvents = new ArrayList<>();
     }
 

--- a/network-events-library/src/androidTest/java/com/github/pwittchen/networkevents/library/receiver/NetworkConnectionChangeReceiverTest.java
+++ b/network-events-library/src/androidTest/java/com/github/pwittchen/networkevents/library/receiver/NetworkConnectionChangeReceiverTest.java
@@ -18,6 +18,7 @@ package com.github.pwittchen.networkevents.library.receiver;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.github.pwittchen.networkevents.library.ConnectivityStatus;
+import com.github.pwittchen.networkevents.library.logger.Logger;
 import com.github.pwittchen.networkevents.library.NetworkState;
 import com.github.pwittchen.networkevents.library.Task;
 import com.github.pwittchen.networkevents.library.TestUtils;
@@ -29,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -46,7 +48,7 @@ public class NetworkConnectionChangeReceiverTest {
     @Before
     public void setUp() throws Exception {
         this.bus = new Bus(ThreadEnforcer.ANY);
-        this.receiver = new NetworkConnectionChangeReceiver(bus, Mockito.mock(Task.class));
+        this.receiver = new NetworkConnectionChangeReceiver(bus, Mockito.mock(Logger.class), Mockito.mock(Task.class));
         this.connectivityChangeEvents = new ArrayList<>();
     }
 

--- a/network-events-library/src/androidTest/java/com/github/pwittchen/networkevents/library/receiver/WifiSignalStrengthChangeReceiverTest.java
+++ b/network-events-library/src/androidTest/java/com/github/pwittchen/networkevents/library/receiver/WifiSignalStrengthChangeReceiverTest.java
@@ -17,6 +17,7 @@ package com.github.pwittchen.networkevents.library.receiver;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import com.github.pwittchen.networkevents.library.logger.Logger;
 import com.github.pwittchen.networkevents.library.event.WifiSignalStrengthChanged;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
@@ -25,6 +26,8 @@ import com.squareup.otto.ThreadEnforcer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +43,7 @@ public class WifiSignalStrengthChangeReceiverTest {
     @Before
     public void setUp() throws Exception {
         this.bus = new Bus(ThreadEnforcer.ANY);
-        this.receiver = new WifiSignalStrengthChangeReceiver(bus);
+        this.receiver = new WifiSignalStrengthChangeReceiver(bus, Mockito.mock(Logger.class));
     }
 
     @Test

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkEvents.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkEvents.java
@@ -20,6 +20,8 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.wifi.WifiManager;
 
+import com.github.pwittchen.networkevents.library.logger.Logger;
+import com.github.pwittchen.networkevents.library.logger.NetworkEventsLogger;
 import com.github.pwittchen.networkevents.library.receiver.InternetConnectionChangeReceiver;
 import com.github.pwittchen.networkevents.library.receiver.NetworkConnectionChangeReceiver;
 import com.github.pwittchen.networkevents.library.receiver.WifiSignalStrengthChangeReceiver;
@@ -49,18 +51,31 @@ public final class NetworkEvents {
 
     /**
      * initializes NetworkEvents object
+     * with NetworkEventsLogger as default logger
      *
      * @param context Android context
      * @param bus     Otto event bus
      */
     public NetworkEvents(Context context, Bus bus) {
+        this(context, bus, new NetworkEventsLogger());
+    }
+
+    /**
+     * initializes NetworkEvents object
+     *
+     * @param context Android context
+     * @param bus     Otto event bus
+     * @param logger  message logger (NetworkEventsLogger logs messages to LogCat, EmptyLogger doesn't log anything)
+     */
+    public NetworkEvents(Context context, Bus bus, Logger logger) {
         validator.checkNotNull(context, "context == null");
         validator.checkNotNull(bus, "bus == null");
+        validator.checkNotNull(logger, "logger == null");
         this.context = context;
         this.pingWrapper = new PingWrapper(context);
-        this.networkConnectionChangeReceiver = new NetworkConnectionChangeReceiver(bus, pingWrapper);
-        this.internetConnectionChangeReceiver = new InternetConnectionChangeReceiver(bus);
-        this.wifiSignalStrengthChangeReceiver = new WifiSignalStrengthChangeReceiver(bus);
+        this.networkConnectionChangeReceiver = new NetworkConnectionChangeReceiver(bus, logger, pingWrapper);
+        this.internetConnectionChangeReceiver = new InternetConnectionChangeReceiver(bus, logger);
+        this.wifiSignalStrengthChangeReceiver = new WifiSignalStrengthChangeReceiver(bus, logger);
     }
 
     /**

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkEventsConfig.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/NetworkEventsConfig.java
@@ -16,7 +16,6 @@
 package com.github.pwittchen.networkevents.library;
 
 public final class NetworkEventsConfig {
-    public final static String TAG = "NetworkEvents";
     public final static String URL = "http://www.google.com";
     public final static int TIMEOUT = 30 * 1000;
     public final static String INTENT = "networkevents.intent.action.INTERNET_CONNECTION_STATE_CHANGED";

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/event/ConnectivityChanged.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/event/ConnectivityChanged.java
@@ -15,9 +15,7 @@
  */
 package com.github.pwittchen.networkevents.library.event;
 
-import android.util.Log;
-
-import com.github.pwittchen.networkevents.library.NetworkEventsConfig;
+import com.github.pwittchen.networkevents.library.logger.Logger;
 import com.github.pwittchen.networkevents.library.ConnectivityStatus;
 
 /**
@@ -29,10 +27,10 @@ import com.github.pwittchen.networkevents.library.ConnectivityStatus;
 public final class ConnectivityChanged {
     private final ConnectivityStatus connectivityStatus;
 
-    public ConnectivityChanged(ConnectivityStatus connectivityStatus) {
+    public ConnectivityChanged(ConnectivityStatus connectivityStatus, Logger logger) {
         this.connectivityStatus = connectivityStatus;
         String message = String.format("ConnectivityChanged: %s", connectivityStatus.toString());
-        Log.d(NetworkEventsConfig.TAG, message);
+        logger.log(message);
     }
 
     public ConnectivityStatus getConnectivityStatus() {

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/logger/EmptyLogger.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/logger/EmptyLogger.java
@@ -13,17 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.pwittchen.networkevents.library.event;
+package com.github.pwittchen.networkevents.library.logger;
 
-import com.github.pwittchen.networkevents.library.logger.Logger;
-
-/**
- * Event pushed to Otto Event Bus when Wifi Signal strength was changed
- * and list of WiFi Access Points was refreshed
- */
-public final class WifiSignalStrengthChanged {
-
-    public WifiSignalStrengthChanged(Logger logger) {
-        logger.log("WifiSignalStrengthChanged");
+public final class EmptyLogger implements Logger {
+    @Override
+    public void log(String message) {
+        // do nothing
     }
 }

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/logger/Logger.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/logger/Logger.java
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.pwittchen.networkevents.library.event;
+package com.github.pwittchen.networkevents.library.logger;
 
-import com.github.pwittchen.networkevents.library.logger.Logger;
-
-/**
- * Event pushed to Otto Event Bus when Wifi Signal strength was changed
- * and list of WiFi Access Points was refreshed
- */
-public final class WifiSignalStrengthChanged {
-
-    public WifiSignalStrengthChanged(Logger logger) {
-        logger.log("WifiSignalStrengthChanged");
-    }
+public interface Logger {
+    void log(String message);
 }

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/logger/NetworkEventsLogger.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/logger/NetworkEventsLogger.java
@@ -13,17 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.pwittchen.networkevents.library.event;
+package com.github.pwittchen.networkevents.library.logger;
 
-import com.github.pwittchen.networkevents.library.logger.Logger;
+import android.util.Log;
 
-/**
- * Event pushed to Otto Event Bus when Wifi Signal strength was changed
- * and list of WiFi Access Points was refreshed
- */
-public final class WifiSignalStrengthChanged {
+public final class NetworkEventsLogger implements Logger {
+    private final static String TAG = "NetworkEvents";
 
-    public WifiSignalStrengthChanged(Logger logger) {
-        logger.log("WifiSignalStrengthChanged");
+    @Override
+    public void log(String message) {
+        Log.d(TAG, message);
     }
 }

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/receiver/BaseBroadcastReceiver.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/receiver/BaseBroadcastReceiver.java
@@ -22,6 +22,7 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.github.pwittchen.networkevents.library.ConnectivityStatus;
+import com.github.pwittchen.networkevents.library.logger.Logger;
 import com.github.pwittchen.networkevents.library.NetworkState;
 import com.github.pwittchen.networkevents.library.event.ConnectivityChanged;
 import com.squareup.otto.Bus;
@@ -29,9 +30,11 @@ import com.squareup.otto.Bus;
 public abstract class BaseBroadcastReceiver extends BroadcastReceiver {
     private final Bus bus;
     private final Handler handler = new Handler(Looper.getMainLooper());
+    protected final Logger logger;
 
-    public BaseBroadcastReceiver(Bus bus) {
+    public BaseBroadcastReceiver(Bus bus, Logger logger) {
         this.bus = bus;
+        this.logger = logger;
     }
 
     @Override
@@ -43,12 +46,12 @@ public abstract class BaseBroadcastReceiver extends BroadcastReceiver {
 
     protected void postConnectivityChanged(ConnectivityStatus connectivityStatus) {
         NetworkState.status = connectivityStatus;
-        postFromAnyThread(new ConnectivityChanged(connectivityStatus));
+        postFromAnyThread(new ConnectivityChanged(connectivityStatus, logger));
     }
 
     protected void postConnectivityChanged(ConnectivityStatus connectivityStatus, Runnable onNext) {
         NetworkState.status = connectivityStatus;
-        postFromAnyThread(new ConnectivityChanged(connectivityStatus));
+        postFromAnyThread(new ConnectivityChanged(connectivityStatus, logger));
         onNext.run();
     }
 

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/receiver/InternetConnectionChangeReceiver.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/receiver/InternetConnectionChangeReceiver.java
@@ -19,13 +19,14 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.github.pwittchen.networkevents.library.ConnectivityStatus;
+import com.github.pwittchen.networkevents.library.logger.Logger;
 import com.github.pwittchen.networkevents.library.NetworkEventsConfig;
 import com.squareup.otto.Bus;
 
 public final class InternetConnectionChangeReceiver extends BaseBroadcastReceiver {
 
-    public InternetConnectionChangeReceiver(Bus bus) {
-        super(bus);
+    public InternetConnectionChangeReceiver(Bus bus, Logger logger) {
+        super(bus, logger);
     }
 
     @Override

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/receiver/NetworkConnectionChangeReceiver.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/receiver/NetworkConnectionChangeReceiver.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.github.pwittchen.networkevents.library.ConnectivityStatus;
+import com.github.pwittchen.networkevents.library.logger.Logger;
 import com.github.pwittchen.networkevents.library.NetworkHelper;
 import com.github.pwittchen.networkevents.library.Task;
 import com.squareup.otto.Bus;
@@ -27,8 +28,8 @@ public final class NetworkConnectionChangeReceiver extends BaseBroadcastReceiver
 
     private Task taskExecutedAfterConnectingToWiFi;
 
-    public NetworkConnectionChangeReceiver(Bus bus, Task taskExecutedAfterConnectingToWiFi) {
-        super(bus);
+    public NetworkConnectionChangeReceiver(Bus bus, Logger logger, Task taskExecutedAfterConnectingToWiFi) {
+        super(bus, logger);
         this.taskExecutedAfterConnectingToWiFi = taskExecutedAfterConnectingToWiFi;
     }
 

--- a/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/receiver/WifiSignalStrengthChangeReceiver.java
+++ b/network-events-library/src/main/java/com/github/pwittchen/networkevents/library/receiver/WifiSignalStrengthChangeReceiver.java
@@ -18,14 +18,15 @@ package com.github.pwittchen.networkevents.library.receiver;
 import android.content.Context;
 import android.content.Intent;
 
+import com.github.pwittchen.networkevents.library.logger.Logger;
 import com.github.pwittchen.networkevents.library.NetworkHelper;
 import com.github.pwittchen.networkevents.library.event.WifiSignalStrengthChanged;
 import com.squareup.otto.Bus;
 
 public final class WifiSignalStrengthChangeReceiver extends BaseBroadcastReceiver {
 
-    public WifiSignalStrengthChangeReceiver(Bus bus) {
-        super(bus);
+    public WifiSignalStrengthChangeReceiver(Bus bus, Logger logger) {
+        super(bus, logger);
     }
 
     @Override
@@ -37,6 +38,6 @@ public final class WifiSignalStrengthChangeReceiver extends BaseBroadcastReceive
     }
 
     public void onPostReceive() {
-        postFromAnyThread(new WifiSignalStrengthChanged());
+        postFromAnyThread(new WifiSignalStrengthChanged(logger));
     }
 }


### PR DESCRIPTION
Solves #58 and #59.
Now, logger implementation can be set during object creation as follows:
```java
new NetworkEvents(context, bus, logger);
```

If we don't pass logger, library will use default logger called `NetworkEventsLogger`, which logs messages to LogCat. If we want to disable logging, we can use `EmptyLogger` class, which doesn't log anything:

```java
new NetworkEvents(context, bus, new EmptyLogger());
```

I know that `EmptyLogger` isn't nice solution, but implementation of `Logger` have to be past during object creation now. We can think of improving it in the future.