### PR TITLE
applying Application Context to NetworkEvents in sample apps and addi…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: android
 
 android:
   components:
-    - build-tools-23.0.1
-    - android-23
+    - build-tools-22.0.1
+    - android-22
     - extra-android-m2repository
     - extra-google-m2repository
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Initialize objects in `onCreate(Bundle savedInstanceState)` method.
 }
 ```
 
+**Please note**: Due to memory leak in `WifiManager` reported
+in [issue 43945](https://code.google.com/p/android/issues/detail?id=43945) in Android issue tracker
+it's recommended to use Application Context instead of Activity Context.
+
 #### NetworkEvents Customization
 
 ##### Custom logger

--- a/example-greenrobot-bus/build.gradle
+++ b/example-greenrobot-bus/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  compileSdkVersion 22
+  buildToolsVersion "22.0.1"
 
   defaultConfig {
     applicationId "com.github.pwittchen.networkevents.greenrobot.app"
     minSdkVersion 15
-    targetSdkVersion 23
+    targetSdkVersion 22
     versionCode 1
     versionName "1.0"
   }
@@ -22,5 +22,5 @@ android {
 dependencies {
   compile(project(':network-events-library'))
   compile 'de.greenrobot:eventbus:2.4.1'
-  compile 'com.android.support:appcompat-v7:23.0.1'
+  compile 'com.android.support:appcompat-v7:22.0.0'
 }

--- a/example-greenrobot-bus/src/main/java/com/github/pwittchen/networkevents/greenrobot/app/MainActivity.java
+++ b/example-greenrobot-bus/src/main/java/com/github/pwittchen/networkevents/greenrobot/app/MainActivity.java
@@ -15,26 +15,23 @@
  */
 package com.github.pwittchen.networkevents.greenrobot.app;
 
+import android.app.Activity;
 import android.net.wifi.ScanResult;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
-
 import com.github.pwittchen.networkevents.library.BusWrapper;
 import com.github.pwittchen.networkevents.library.NetworkEvents;
 import com.github.pwittchen.networkevents.library.event.ConnectivityChanged;
 import com.github.pwittchen.networkevents.library.event.WifiSignalStrengthChanged;
-
+import de.greenrobot.event.EventBus;
 import java.util.ArrayList;
 import java.util.List;
 
-import de.greenrobot.event.EventBus;
-
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends Activity {
   private BusWrapper busWrapper;
   private NetworkEvents networkEvents;
 
@@ -68,7 +65,7 @@ public class MainActivity extends AppCompatActivity {
     accessPoints = (ListView) findViewById(R.id.access_points);
     final EventBus bus = new EventBus();
     busWrapper = getGreenRobotBusWrapper(bus);
-    networkEvents = new NetworkEvents(this, busWrapper).enableWifiScan();
+    networkEvents = new NetworkEvents(getApplicationContext(), busWrapper).enableWifiScan();
   }
 
   @NonNull private BusWrapper getGreenRobotBusWrapper(final EventBus bus) {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  compileSdkVersion 22
+  buildToolsVersion "22.0.1"
 
   defaultConfig {
     applicationId "com.github.pwittchen.networkevents.app"
     minSdkVersion 15
-    targetSdkVersion 23
+    targetSdkVersion 22
     versionCode 1
     versionName "1.0"
   }
@@ -22,5 +22,5 @@ android {
 dependencies {
   compile project(':network-events-library')
   compile 'com.squareup:otto:1.3.8'
-  compile 'com.android.support:appcompat-v7:23.0.1'
+  compile 'com.android.support:appcompat-v7:22.0.0'
 }

--- a/example/src/main/java/com/github/pwittchen/networkevents/app/MainActivity.java
+++ b/example/src/main/java/com/github/pwittchen/networkevents/app/MainActivity.java
@@ -15,26 +15,24 @@
  */
 package com.github.pwittchen.networkevents.app;
 
+import android.app.Activity;
 import android.net.wifi.ScanResult;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
-
 import com.github.pwittchen.networkevents.library.BusWrapper;
 import com.github.pwittchen.networkevents.library.NetworkEvents;
 import com.github.pwittchen.networkevents.library.event.ConnectivityChanged;
 import com.github.pwittchen.networkevents.library.event.WifiSignalStrengthChanged;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends Activity {
   private BusWrapper busWrapper;
   private NetworkEvents networkEvents;
 
@@ -67,7 +65,7 @@ public class MainActivity extends AppCompatActivity {
     mobileNetworkType = (TextView) findViewById(R.id.mobile_network_type);
     accessPoints = (ListView) findViewById(R.id.access_points);
     busWrapper = getOttoBusWrapper(new Bus());
-    networkEvents = new NetworkEvents(this, busWrapper).enableWifiScan();
+    networkEvents = new NetworkEvents(getApplicationContext(), busWrapper).enableWifiScan();
   }
 
   @NonNull private BusWrapper getOttoBusWrapper(final Bus bus) {

--- a/network-events-library/build.gradle
+++ b/network-events-library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  compileSdkVersion 22
+  buildToolsVersion "22.0.1"
 
   defaultConfig {
     minSdkVersion 9
-    targetSdkVersion 23
+    targetSdkVersion 22
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/network-events-library/src/main/AndroidManifest.xml
+++ b/network-events-library/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
   <application/>
 </manifest>


### PR DESCRIPTION
…ng new permission to satisfy Android 6 requirements for WiFi scanning

targetSdk was temporarily decreased to 22 due to added permission.
Introducing new permission model can be subject of future improvements.

Updates in this PR are related to issue #106 and this discussion: http://stackoverflow.com/questions/32151603/scan-results-available-action-return-empty-list-in-android-6-0